### PR TITLE
Remove unused import in data augmentation notebook

### DIFF
--- a/site/en/tutorials/images/data_augmentation.ipynb
+++ b/site/en/tutorials/images/data_augmentation.ipynb
@@ -96,8 +96,7 @@
         "import tensorflow as tf\n",
         "import tensorflow_datasets as tfds\n",
         "\n",
-        "from tensorflow.keras import layers\n",
-        "from tensorflow.keras.datasets import mnist"
+        "from tensorflow.keras import layers"
       ]
     },
     {

--- a/site/en/tutorials/images/data_augmentation.ipynb
+++ b/site/en/tutorials/images/data_augmentation.ipynb
@@ -82,7 +82,6 @@
         "## Setup"
       ]
     },
-
     {
       "cell_type": "code",
       "execution_count": null,


### PR DESCRIPTION
Hi. The data augmentation notebook has an unused import, related to the dataset mnist.

Though it's a minor issue, it nevertheless may confuse people why the mnist is being import if throughout the entire notebook another dataset is being used (flowers).
